### PR TITLE
Allow installation from locally cloned git repo

### DIFF
--- a/quad/checksum.rkt
+++ b/quad/checksum.rkt
@@ -4,6 +4,6 @@
 
 (define (pkg-checksum [pkg "quad"] #:short [short? #false])
   (match (for/or ([scope (in-list '(user installation shared))])
-                 (hash-ref (read-pkgs-db scope) pkg #false))
-    [(pkg-info _ checksum _) (if short? (substring checksum 0 7) checksum)]
+           (hash-ref (read-pkgs-db scope) pkg #false))
+    [(pkg-info _ (? string? checksum) _) (if short? (substring checksum 0 7) checksum)]
     [_ "checksum not found"]))


### PR DESCRIPTION
pkg-info might contain a #f checksum, causing substring to raise a contract
error. This commit avoids the error.